### PR TITLE
Update :avro_util.is_valid_name_char/1 to allow hyphens

### DIFF
--- a/src/avro_util.erl
+++ b/src/avro_util.erl
@@ -556,7 +556,8 @@ reserved_type_names() ->
 is_valid_name_head(S) ->
   (S >= $A andalso S =< $Z) orelse
   (S >= $a andalso S =< $z) orelse
-  S =:= $_.
+  S =:= $_ orelse
+  S =:= $-.
 
 %% @private In addition to what applies to leading char, body char can be 0-9.
 is_valid_name_char(S) -> is_valid_name_head(S) orelse

--- a/test/avro_util_tests.erl
+++ b/test/avro_util_tests.erl
@@ -48,7 +48,7 @@ tokens_ex_test() ->
   ?assertEqual(["ab", "cd"], tokens_ex("ab.cd", $.)).
 
 is_valid_name_test() ->
-  ValidNames = ["_", "a", "Aa1", "a_A"],
+  ValidNames = ["_", "a", "Aa1", "a_A", "a-A"],
   InvalidNames = ["", "1", " a", "a ", " a ", ".", "a.b.c"],
   [?assert(is_valid_name(Name)) || Name <- ValidNames],
   [?assertNot(is_valid_name(Name)) || Name <- InvalidNames].


### PR DESCRIPTION
erl_avro's name validations did not allow for hyphens.  Hyphens are present in our kafka topic names.  This PR modifies the name validation logic to allow for hyphens anywhere in the given name (including 1st character).

To validate this against our codebase I modified [this line](https://github.com/carsdotcom/cars_platform/blob/97127c9878796da5dafdb0236f32bd3717ecddae/apps/manifold/test/manifold/consumers/data_science/price_badge_consumer_test.exs#L16) in this branch: `marketplace/CARS-104/debug-ml-listing-consumer` by adding a hyphen to the namespace.  The tests failed with the `:invalid_name` error as seen in NP.
I then updated `cars_platform/apps/kafka_repo/mix.exs`'s erl_avro dep to point to my local repo
`{:erlavro, path: "/Users/leepage/repos/erlavro", override: true},`
and the test passed.  I dont know if there will be any other downstream effects.

Input appreciated.  I have never written erlang before.

Relates to:
https://github.com/carsdotcom/cars_platform/pull/12525
and the subsequent revert:
https://github.com/carsdotcom/cars_platform/pull/12596
